### PR TITLE
ci(build-and-release.yml): Update Setup Typst to v4

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,10 +34,10 @@ jobs:
           sudo mv fontawesome-free-6.4.2-desktop /usr/share/fonts
           sudo fc-cache -fv
         
-      - uses: yusancky/setup-typst@v3.1.0
+      - uses: typst-community/setup-typst@v4.2.0
         id: setup-typst
         with:
-          version: 'latest'
+          typst-version: 'latest'
 
       - name: Build documents
         run: for file in `ls *typ`; do typst compile $file; done


### PR DESCRIPTION
Bump Setup Typst to v4

> [!WARNING] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://gist.github.com/yusancky/b676f56d40d6346dfc67ed477ca2ea1a) for more information.

> [!TIP]
> You have other repositories that are also using this old GitHub Action that has been migrated, but I have only opened a PR in this repository for your reference to decide whether to update the Action. You can consider [checking the search page](https://github.com/search?q=yusancky%2Fsetup-typst+++language%3AYAML+path%3A%2F%5E%5C.github%5C%2Fworkflows%5C%2F%2F++NOT+is%3Aarchived++owner%3Adomm99&type=code) to see other repositories that might need modifications and choose which ones to update as needed.